### PR TITLE
feat: explicitly type global layout

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,6 +31,8 @@
 	"parser": "@typescript-eslint/parser",
 	"plugins": ["@typescript-eslint", "react"],
 	"rules": {
+		"@typescript-eslint/no-empty-interface": ["error", { "allowSingleExtends": true }],
+		"no-console": "error",
 		"sort-imports": "error"
 	},
 	"settings": {

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -20,10 +20,8 @@ const config = defineConfig({
 		setupNodeEvents: (on, config) => {
 			on("before:browser:launch", (browser, options) => {
 				if (browser.family === "chromium" && config.env.DARK_MODE) {
-					console.log("PUSHING FLAG!!!");
 					options.args.push("--force-dark-mode=true");
 					options.args.push("--enable-force-dark=true");
-					console.log(options.args);
 					return options;
 				}
 			});
@@ -31,7 +29,9 @@ const config = defineConfig({
 			return {
 				...config,
 				browsers: config.browsers.filter((browser) =>
-					config.env.DARK_MODE ? browser.name !== "electron" : true
+					config.env.DARK_MODE && config.browsers.length > 1
+						? browser.name !== "electron"
+						: true
 				),
 			};
 		},

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"clean": "gatsby clean",
 		"cy:open": "cypress open",
 		"cy:run": "cypress run",
-		"cy:run:dark-mode": "CYPRESS_DARK_MODE=true cypress run --browser chromium",
+		"cy:run:dark-mode": "CYPRESS_DARK_MODE=true cypress run",
 		"cy:run:component": "cypress run --component",
 		"develop": "gatsby develop",
 		"lint": "eslint",

--- a/src/components/Branding/Branding.cy.tsx
+++ b/src/components/Branding/Branding.cy.tsx
@@ -1,13 +1,14 @@
-import { Locale, LocaleContext } from "../../utils/localization";
 import { Branding } from "./";
+import { ContextProvider } from "src/utils/context";
+import { Locale } from "../../utils/localization";
 import React from "react";
 
 describe("<Branding>", () => {
 	it("should show the logo", () => {
 		cy.mount(
-			<LocaleContext.Provider value={{ locale: Locale.enUs }}>
+			<ContextProvider value={{ locale: Locale.enUs }}>
 				<Branding />
-			</LocaleContext.Provider>
+			</ContextProvider>
 		)
 			.get("img")
 			.should("be.visible");
@@ -15,9 +16,9 @@ describe("<Branding>", () => {
 
 	it("should render an h1 on home pages", () => {
 		cy.mount(
-			<LocaleContext.Provider value={{ locale: Locale.enUs }}>
-				<Branding isHome={true} />
-			</LocaleContext.Provider>
+			<ContextProvider value={{ isHome: true, locale: Locale.enUs }}>
+				<Branding />
+			</ContextProvider>
 		)
 			.get("h1")
 			.should("be.visible")
@@ -26,9 +27,9 @@ describe("<Branding>", () => {
 
 	it("should render a span on non-home pages", () => {
 		cy.mount(
-			<LocaleContext.Provider value={{ locale: Locale.enUs }}>
+			<ContextProvider value={{ locale: Locale.enUs }}>
 				<Branding />
-			</LocaleContext.Provider>
+			</ContextProvider>
 		)
 			.get("span")
 			.should("be.visible")

--- a/src/components/Branding/Branding.test.tsx
+++ b/src/components/Branding/Branding.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import { Branding } from "./";
+import { ContextProvider } from "../../utils/context";
+import { Locale } from "../../utils/localization";
+import React from "react";
+
+describe("<Branding>", () => {
+	it("should render an h1 on home pages", async () => {
+		render(
+			<ContextProvider value={{ isHome: true, locale: Locale.enUs }}>
+				<Branding />
+			</ContextProvider>
+		);
+
+		const h1s = await screen.getAllByRole("heading", { level: 1 });
+
+		expect(h1s[0]).toBeInTheDocument();
+		expect(h1s[1]).toBeInTheDocument();
+	});
+
+	it("should render a span on non-home pages", async () => {
+		render(<Branding />);
+
+		expect(() => screen.getByRole("heading", { level: 1 })).toThrowError();
+		expect(screen.getByText("Griffen")).toBeInTheDocument();
+		expect(screen.getByText("Griffen Schwiesow")).toBeInTheDocument();
+	});
+});

--- a/src/components/Branding/index.tsx
+++ b/src/components/Branding/index.tsx
@@ -8,56 +8,53 @@ import {
 	brandingTitle,
 	brandingTitleShort,
 } from "../../styles";
+import { ContextConsumer } from "../../utils/context";
 import { Link } from "gatsby";
-import { LocaleContext } from "../../utils/localization";
 import React from "react";
 import { StaticImage } from "gatsby-plugin-image";
+import { getSlugPrefix } from "../../utils/localization";
 
-interface IBrandingProps {
-	isHome?: boolean;
-}
-
-class Branding extends React.Component<IBrandingProps> {
+class Branding extends React.Component {
 	render(): React.ReactNode {
-		const { isHome } = this.props;
-
-		const TitleElement = isHome ? "h1" : "span";
-
 		return (
-			<LocaleContext.Consumer>
-				{({ locale }) => (
-					<div className={branding}>
-						<Link
-							aria-label={"Griffen Schwiesow logo"}
-							className={brandingLink}
-							to={"/"}
-						>
-							<StaticImage
-								alt={""}
-								height={40}
-								layout={"fixed"}
-								loading={"eager"}
-								placeholder={"blurred"}
-								src={"../../assets/icon.png"}
-							/>
+			<ContextConsumer>
+				{({ isHome, locale }) => {
+					const TitleElement = isHome ? "h1" : "span";
 
-							<TitleElement className={brandingTitle}>
-								{getTranslatedString(
-									locale,
-									TranslationString.Title
-								)}
-							</TitleElement>
+					return (
+						<div className={branding}>
+							<Link
+								aria-label={"Griffen Schwiesow logo"}
+								className={brandingLink}
+								to={getSlugPrefix(locale)}
+							>
+								<StaticImage
+									alt={""}
+									height={40}
+									layout={"fixed"}
+									loading={"eager"}
+									placeholder={"blurred"}
+									src={"../../assets/icon.png"}
+								/>
 
-							<TitleElement className={brandingTitleShort}>
-								{getTranslatedString(
-									locale,
-									TranslationString.TitleShort
-								)}
-							</TitleElement>
-						</Link>
-					</div>
-				)}
-			</LocaleContext.Consumer>
+								<TitleElement className={brandingTitle}>
+									{getTranslatedString(
+										locale,
+										TranslationString.Title
+									)}
+								</TitleElement>
+
+								<TitleElement className={brandingTitleShort}>
+									{getTranslatedString(
+										locale,
+										TranslationString.TitleShort
+									)}
+								</TitleElement>
+							</Link>
+						</div>
+					);
+				}}
+			</ContextConsumer>
 		);
 	}
 }

--- a/src/components/Header/Header.test.tsx
+++ b/src/components/Header/Header.test.tsx
@@ -1,14 +1,15 @@
-import { Locale, LocaleContext } from "../../utils/localization";
 import { render, screen } from "@testing-library/react";
+import { ContextProvider } from "../../utils/context";
 import { Header } from "./";
+import { Locale } from "../../utils/localization";
 import React from "react";
 
 describe("<Header>", () => {
 	it("should render a header", () => {
 		render(
-			<LocaleContext.Provider value={{ locale: Locale.enUs }}>
+			<ContextProvider value={{ locale: Locale.enUs }}>
 				<Header />
-			</LocaleContext.Provider>
+			</ContextProvider>
 		);
 		expect(screen.getByRole("banner")).toBeInTheDocument();
 	});

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -2,18 +2,12 @@ import { header, headerContent } from "../../styles";
 import { Branding } from "../";
 import React from "react";
 
-interface IHeaderProps {
-	isHome?: boolean;
-}
-
-class Header extends React.Component<IHeaderProps> {
+class Header extends React.Component {
 	render(): React.ReactNode {
-		const { isHome } = this.props;
-
 		return (
 			<header className={header}>
 				<div className={headerContent}>
-					<Branding isHome={isHome} />
+					<Branding />
 				</div>
 			</header>
 		);

--- a/src/components/Layout/Layout.test.tsx
+++ b/src/components/Layout/Layout.test.tsx
@@ -1,14 +1,15 @@
-import { Locale, LocaleContext } from "../../utils/localization";
 import { render, screen } from "@testing-library/react";
+import { ContextProvider } from "../../utils/context";
 import { Layout } from "./";
+import { Locale } from "../../utils/localization";
 import React from "react";
 
 describe("<Layout>", () => {
 	it("should render a main region", () => {
 		render(
-			<LocaleContext.Provider value={{ locale: Locale.enUs }}>
+			<ContextProvider value={{ locale: Locale.enUs }}>
 				<Layout />
-			</LocaleContext.Provider>
+			</ContextProvider>
 		);
 		expect(screen.getByRole("main")).toBeInTheDocument();
 	});

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -3,16 +3,15 @@ import React from "react";
 
 interface ILayoutProps {
 	children?: React.ReactNode;
-	isHome?: boolean;
 }
 
 class Layout extends React.Component<ILayoutProps> {
 	render(): React.ReactNode {
-		const { children, isHome } = this.props;
+		const { children } = this.props;
 
 		return (
 			<>
-				<Header isHome={isHome} />
+				<Header />
 
 				<Main>{children}</Main>
 

--- a/src/components/Seo/Seo.test.tsx
+++ b/src/components/Seo/Seo.test.tsx
@@ -1,14 +1,13 @@
-import { Locale, LocaleContext } from "../../utils/localization";
+import { ContextProvider } from "../../utils/context";
 import { Helmet } from "react-helmet";
+import { Locale } from "../../utils/localization";
 import React from "react";
 import { Seo } from "./";
 import { render as testingLibraryRender } from "@testing-library/react";
 
-const render: typeof testingLibraryRender = (ui: React.ReactElement) =>
+const render = (ui: React.ReactElement) =>
 	testingLibraryRender(
-		<LocaleContext.Provider value={{ locale: Locale.enUs }}>
-			{ui}
-		</LocaleContext.Provider>
+		<ContextProvider value={{ locale: Locale.enUs }}>{ui}</ContextProvider>
 	);
 
 describe("<Seo>", () => {

--- a/src/components/Seo/index.tsx
+++ b/src/components/Seo/index.tsx
@@ -1,6 +1,7 @@
-import { LocaleContext, getLang } from "../../utils/localization";
+import { ContextConsumer } from "../../utils/context";
 import { Helmet } from "react-helmet";
 import React from "react";
+import { getLang } from "../../utils/localization";
 
 interface ISeoProps {
 	description?: string;
@@ -25,7 +26,7 @@ class Seo extends React.Component<ISeoProps> {
 		}
 
 		return (
-			<LocaleContext.Consumer>
+			<ContextConsumer>
 				{({ locale }) => (
 					<Helmet
 						htmlAttributes={{ lang: lang || getLang(locale) }}
@@ -33,7 +34,7 @@ class Seo extends React.Component<ISeoProps> {
 						meta={[...optionalMetaItems]}
 					/>
 				)}
-			</LocaleContext.Consumer>
+			</ContextConsumer>
 		);
 	}
 }

--- a/src/templates/home.tsx
+++ b/src/templates/home.tsx
@@ -1,5 +1,5 @@
 import { TranslationString, getTranslatedString } from "src/utils/translation";
-import { LocaleContext } from "../utils/localization";
+import { ContextConsumer } from "../utils/context";
 import React from "react";
 import { Seo } from "../components";
 import { graphql } from "gatsby";
@@ -24,7 +24,7 @@ class HomeTemplate extends React.Component<IHomeTemplateProps> {
 		const { seo, title } = frontmatter;
 
 		return (
-			<LocaleContext.Consumer>
+			<ContextConsumer>
 				{({ locale }) => (
 					<>
 						<Seo
@@ -41,7 +41,7 @@ class HomeTemplate extends React.Component<IHomeTemplateProps> {
 						<span>{title}</span>
 					</>
 				)}
-			</LocaleContext.Consumer>
+			</ContextConsumer>
 		);
 	}
 }

--- a/src/utils/__tests__/localization.test.ts
+++ b/src/utils/__tests__/localization.test.ts
@@ -1,4 +1,10 @@
-import { Locale, getLang, getLocale } from "../localization";
+import {
+	Locale,
+	getLang,
+	getLocale,
+	getLocalizedNodeData,
+	getSlugPrefix,
+} from "../localization";
 
 describe("getLang()", () => {
 	const nonEnglishLocales = [Locale.deCh, Locale.jaJp];
@@ -27,6 +33,63 @@ describe("getLocale()", () => {
 	it("should return expected locales for given cases", () => {
 		Object.entries(localeCases).forEach(([locale, cases]) => {
 			cases.forEach((value) => expect(getLocale(value)).toBe(locale));
+		});
+	});
+});
+
+describe("getLocalizedNodeData()", () => {
+	it("should default to english page with uid for a given node", () => {
+		const { locale, slug } = getLocalizedNodeData({
+			frontmatter: {
+				slug: "test-page",
+			},
+			id: "",
+		});
+
+		expect(locale).toBe(Locale.enUs);
+		expect(slug).toBe("/test-page/");
+	});
+
+	it("should return only the locale prefix for home nodes", () => {
+		const { locale, slug } = getLocalizedNodeData({
+			frontmatter: {
+				locale: "de-CH",
+				slug: "test-page",
+				template: "home",
+			},
+			id: "",
+		});
+
+		expect(locale).toBe(Locale.deCh);
+		expect(slug).toBe(getSlugPrefix(Locale.deCh));
+	});
+
+	it("should throw an error if slug is not given for non-home node", () => {
+		expect(() =>
+			getLocalizedNodeData({ frontmatter: {}, id: "" })
+		).toThrowError();
+	});
+});
+
+describe("getSlugPrefix()", () => {
+	const localeCases = [
+		{
+			locale: Locale.deCh,
+			result: "/de/",
+		},
+		{
+			locale: Locale.enUs,
+			result: "/",
+		},
+		{
+			locale: Locale.jaJp,
+			result: "/ja/",
+		},
+	];
+
+	it("should return the expected prefix for each locale", () => {
+		localeCases.forEach(({ locale, result }) => {
+			expect(getSlugPrefix(locale)).toBe(result);
 		});
 	});
 });

--- a/src/utils/__tests__/translation.test.ts
+++ b/src/utils/__tests__/translation.test.ts
@@ -1,5 +1,6 @@
 import {
 	TranslationString,
+	deCh,
 	enUs,
 	getTranslatedString,
 	jaJp,
@@ -8,16 +9,26 @@ import { Locale } from "../localization";
 
 describe("getTranslatedString()", () => {
 	it("should return the translated string for the given locale", () => {
-		const englishResult = getTranslatedString(
-			Locale.enUs,
-			TranslationString.Title
-		);
-		expect(englishResult).toBe(enUs[TranslationString.Title]);
+		const tests = [
+			{
+				input: TranslationString.Title,
+				locale: Locale.deCh,
+				output: deCh[TranslationString.Title],
+			},
+			{
+				input: TranslationString.Title,
+				locale: Locale.enUs,
+				output: enUs[TranslationString.Title],
+			},
+			{
+				input: TranslationString.Title,
+				locale: Locale.jaJp,
+				output: jaJp[TranslationString.Title],
+			},
+		];
 
-		const japaneseResult = getTranslatedString(
-			Locale.jaJp,
-			TranslationString.Title
+		tests.forEach(({ input, locale, output }) =>
+			expect(getTranslatedString(locale, input)).toBe(output)
 		);
-		expect(japaneseResult).toBe(jaJp[TranslationString.Title]);
 	});
 });

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -1,0 +1,17 @@
+import { Locale } from "./localization";
+import React from "react";
+
+interface IContext {
+	isHome?: boolean;
+	locale: Locale;
+}
+
+export const defaultContext: IContext = {
+	locale: Locale.enUs,
+};
+
+const Context = React.createContext<IContext>(defaultContext);
+
+export const ContextConsumer = Context.Consumer;
+
+export const ContextProvider = Context.Provider;

--- a/src/utils/layout.tsx
+++ b/src/utils/layout.tsx
@@ -1,14 +1,51 @@
-import type { GatsbyBrowser, GatsbySSR } from "gatsby";
-import { LocaleContext, getLocale } from "./localization";
+import { ILocalizedNodeData, Locale } from "./localization";
+import type {
+	PluginOptions,
+	WrapPageElementBrowserArgs,
+	WrapPageElementNodeArgs,
+} from "gatsby";
+import { ContextProvider } from "./context";
 import { Layout } from "../components";
 import React from "react";
 
-export const wrapPageElement:
-	| GatsbyBrowser["wrapPageElement"]
-	| GatsbySSR["wrapPageElement"] = ({ element, props }) => (
-	<LocaleContext.Provider
-		value={{ locale: getLocale(props.pageContext.locale) }}
+export interface IPageContextArgs {
+	id: string;
+	isHome?: boolean;
+	locale: Locale;
+	localizations?: Array<ILocalizedNodeData>;
+}
+
+interface IWrapPageElementBrowserArgs
+	extends WrapPageElementBrowserArgs<
+		Record<string, unknown>,
+		IPageContextArgs,
+		unknown
+	> {}
+
+interface IWrapPageElementNodeArgs
+	extends WrapPageElementNodeArgs<
+		Record<string, unknown>,
+		IPageContextArgs
+	> {}
+
+type WrapPageElement = {
+	(
+		args: IWrapPageElementBrowserArgs,
+		options: PluginOptions
+	): React.ReactElement;
+	(
+		args: IWrapPageElementNodeArgs,
+		options: PluginOptions
+	): React.ReactElement;
+};
+
+export const wrapPageElement: WrapPageElement = ({ element, props }) => (
+	<ContextProvider
+		value={{
+			isHome: props.pageContext.isHome,
+			locale: props.pageContext.locale,
+		}}
 	>
-		<Layout isHome={!!props.pageContext.isHome}>{element}</Layout>
-	</LocaleContext.Provider>
+		<Layout>{element}</Layout>
+	</ContextProvider>
 );

--- a/src/utils/localization.ts
+++ b/src/utils/localization.ts
@@ -1,18 +1,10 @@
-import React from "react";
+import type { ICreatePagesQueryDataAllMarkdownRemarkNode } from "../../gatsby-node";
 
 export enum Locale {
 	deCh = "de-CH",
 	enUs = "en-US",
 	jaJp = "ja-JP",
 }
-
-interface ILocaleContext {
-	locale: Locale;
-}
-
-export const LocaleContext = React.createContext<ILocaleContext>({
-	locale: Locale.enUs,
-});
 
 export const getLang = (locale: Locale): string => {
 	switch (locale) {
@@ -42,4 +34,48 @@ export const getLocale = (locale: unknown): Locale => {
 		default:
 			return Locale.enUs;
 	}
+};
+
+export const getSlugPrefix = (locale: Locale): string => {
+	switch (locale) {
+		case Locale.deCh:
+			return "/de/";
+
+		case Locale.jaJp:
+			return "/ja/";
+
+		default:
+			return "/";
+	}
+};
+
+export interface ILocalizedNodeData {
+	locale: Locale;
+	slug: string;
+}
+
+export const getLocalizedNodeData = (
+	node: ICreatePagesQueryDataAllMarkdownRemarkNode
+): ILocalizedNodeData => {
+	const { locale, slug, template } = node.frontmatter;
+	const actualLocale = getLocale(locale);
+
+	const prefix = getSlugPrefix(actualLocale);
+
+	let actualSlug: string;
+
+	switch (template) {
+		case "home":
+			actualSlug = prefix;
+			break;
+
+		default:
+			if (!slug) throw new Error("no slug present for non-home node");
+			actualSlug = `${prefix}${slug}/`;
+	}
+
+	return {
+		locale: actualLocale,
+		slug: actualSlug,
+	};
 };

--- a/src/utils/translation/index.ts
+++ b/src/utils/translation/index.ts
@@ -1,19 +1,23 @@
 import { Locale } from "../localization";
-import type { TranslationMap } from "./strings";
 import { TranslationString } from "./strings";
 import deCh from "./strings/deCh";
 import enUs from "./strings/enUs";
 import jaJp from "./strings/jaJp";
 
-const translations: TranslationMap = {
-	[Locale.deCh]: deCh,
-	[Locale.enUs]: enUs,
-	[Locale.jaJp]: jaJp,
-};
-
 export const getTranslatedString = (
 	locale: Locale,
 	str: TranslationString
-): string => translations[locale][str];
+): string => {
+	switch (locale) {
+		case Locale.deCh:
+			return deCh[str];
+
+		case Locale.jaJp:
+			return jaJp[str];
+
+		default:
+			return enUs[str];
+	}
+};
 
 export { TranslationString, deCh, enUs, jaJp };


### PR DESCRIPTION
instead of using union type of `GatsbyBrowser["wrapPageElement"]` and `GatsbySSR["wrapPageElement"]`, explicitly type the `wrapPageElement` function with expected props that complies with both `GatsbyBrowser` and `GatsbySSR` implementations.